### PR TITLE
Remove parallelStream since ArrayList is not thread-safe

### DIFF
--- a/src/main/java/io/gitlab/rxp90/jsymspell/SymSpellImpl.java
+++ b/src/main/java/io/gitlab/rxp90/jsymspell/SymSpellImpl.java
@@ -40,7 +40,7 @@ public class SymSpellImpl implements SymSpell {
         this.bigramLexicon = new HashMap<>(builder.getBigramLexicon());
         this.stringDistance = builder.getStringDistanceAlgorithm();
         this.n = unigramLexicon.values().stream().reduce(Long::sum).orElse(0L);
-        this.unigramLexicon.keySet().parallelStream().forEach(word ->{
+        this.unigramLexicon.keySet().forEach(word ->{
             Map<String, Collection<String>> edits = generateEdits(word);
             edits.forEach((string, suggestions) -> this.deletes.computeIfAbsent(string, ignored -> new ArrayList<>()).addAll(suggestions));
         });


### PR DESCRIPTION
Thanks for creating this awesome project. I noticed that sometimes there are `null` entries in `SymSpellImpl.deletes` inside the collection values. I think it is caused by the usage of `ArrayList.addAll()` and `parallelStream` since `ArrayList` is not thread-safe. After removing the `parallelStream`, it is working fine (no more null entries in the values collection).